### PR TITLE
Add offset to `cyclic_encode`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Note: All methods in this package are meant to be used inline within a select st
 | [label_encode](#label_encode)             | ✅           | ✅             | ✅          |
 | [one_hot_encode](#one_hot_encode)         | ✅           | ✅             | ✅          |
 | [rare_category_encode](#rare_category_encode) | ✅      | ✅             | ✅          |
+| [cyclic_encode](#cyclic_encode)           | ✅           | ✅             | ✅          |
 | [exponentiate](#exponentiate)             | ✅           | ✅             | ✅          |
 | [interact](#interact)                     | ✅           | ✅             | ✅          |
 | [k_bins_discretize](#k_bins_discretize)   | ✅           | ✅             | ✅          |
@@ -26,7 +27,7 @@ Note: All methods in this package are meant to be used inline within a select st
 | [poly_transform](#poly_transform)         | ✅           | ✅             | ✅           
 | [robust_scale](#robust_scale)             | ✅           | ✅             | ✅          |
 | [standardize](#standardize)               | ✅           | ✅             | ✅          |
-| [cyclic_encode](#cyclic_encode)           | ✅           | ✅             | ✅          |
+
 
 
 ## Installation Instructions
@@ -263,6 +264,7 @@ This macro encodes cyclical time or date features (such as hour of day, day of w
 
 - `column` (required): The column containing the datetime or cyclical value to encode.
 - `period` (required): The type of period to encode. Supported values: `hour_of_day`, `day_of_week`, `day_of_month`, `month_of_year`, `week_of_year`.
+- `offset` (optional): The amount of offset to apply to the raw number being input before encoding.
 - `func` (optional): The trigonometric function to use for encoding (e.g., `'sin'` or `'cos'`). Default is `'sin'`.
 
 **Usage:**
@@ -271,6 +273,7 @@ This macro encodes cyclical time or date features (such as hour of day, day of w
 {{ dbt_ml_inline_preprocessing.cyclic_encode(
     column='created_at',
     period='hour_of_day',
+    offset=0,
     func='sin'
 ) }}
 ```

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -2,7 +2,7 @@ name: "ml_inline_preprocessing_integration_tests"
 version: "1.0"
 config-version: 2
 
-profile: "integration_tests_postgres"
+profile: "integration_tests_duckdb"
 
 model-paths: ["models"]
 test-paths: ["tests"]

--- a/macros/cyclic_encode.sql
+++ b/macros/cyclic_encode.sql
@@ -1,8 +1,11 @@
-{% macro cyclic_encode(column, period, func='sin') %}
-    {{ return(adapter.dispatch('cyclic_encode', 'dbt_ml_inline_preprocessing')(column, period, func)) }}
+{% macro cyclic_encode(column, period, offset=0, func='sin') %}
+    {{ return(adapter.dispatch('cyclic_encode', 'dbt_ml_inline_preprocessing')(column, period, offset, func)) }}
 {% endmacro %}
 
-{% macro default__cyclic_encode(column, period, func='sin') %}
+{% macro default__cyclic_encode(column, period, offset, func='sin') %}
+
+    {% set pi = 3.141592653589793 %}
+
     {# Map period -> extract expression + cycle length #}
     {% if period == "hour_of_day" %}
         {% set expr = "extract(hour from " ~ column ~ ")" %}
@@ -27,6 +30,6 @@
         ) }}
     {% endif %}
 
-    {{ func }}(2 * pi() * ({{ expr }}::float / {{ max_val }}))
+    {{ func }}((2 * {{ pi }} * ({{ expr }}::float + {{ offset }})) / ({{ max_val }}::float))
 
 {% endmacro %}

--- a/macros/schema.yml
+++ b/macros/schema.yml
@@ -222,6 +222,9 @@ macros:
       - name: period
         type: string
         description: The type of period to encode. Supported values -> hour_of_day, day_of_week, day_of_month, month_of_year, week_of_year.
+      - name: offset
+        type: float
+        description: The amount of offset to apply the value before encoding.
       - name: func
         type: string
         description: The trigonometric function to use for encoding (e.g., 'sin' or 'cos'). Default is 'sin'.


### PR DESCRIPTION
Fixes #12

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

Adds in an offset parameter to the cyclic encoding function before encoding is performed

## Checklist
- [X] I have verified that these changes work locally
- [X] I have updated the README.md (if applicable)
- [X] I have added tests & descriptions to my models (and macros if applicable)