### PR TITLE
Cast snowflake__numerical_impute output to FLOAT

### DIFF
--- a/macros/numerical_impute.sql
+++ b/macros/numerical_impute.sql
@@ -45,11 +45,11 @@
 {% macro snowflake__numerical_impute(column, measure, percentile, source_relation)  %}
 
     {% if measure == 'mean' %}
-        coalesce({{ column }}, avg({{ column }}) over ())
+        coalesce({{ column }}, avg({{ column }}) over ())::float
     {% elif measure == 'median' %}
-        coalesce({{ column }}, percentile_cont(0.5) within group (order by {{ column }}) over ())
+        coalesce({{ column }}, percentile_cont(0.5) within group (order by {{ column }}) over ())::float
     {% elif measure == 'percentile' %}
-        coalesce({{ column }}, percentile_cont({{ percentile }}) within group (order by {{ column }}) over ())
+        coalesce({{ column }}, percentile_cont({{ percentile }}) within group (order by {{ column }}) over ())::float
     {% endif %}
 
 {% endmacro %}


### PR DESCRIPTION
## Summary

- Adds `::float` cast to all three branches of `snowflake__numerical_impute` (mean, median, percentile)
- Prevents `NUMBER(p, s>0)` output from causing silent feature drops in the Snowflake ML model registry

## Why

Snowflake's `avg()` and `percentile_cont()` return `NUMBER(38, s)` (a scale-aware decimal). When these columns flow into a model registered with `snowflake.ml.registry.Registry.log_model()`, the registry silently omits them from the generated `PREDICT` SQL signature. At inference time, the feature count mismatch causes a `ValueError`.

Casting to `FLOAT` ensures the column type is treated as a true floating-point and is included in the registered signature.

Closes #31

## Test plan

- [ ] Verify `numerical_impute` with `measure='mean'` compiles to `coalesce(...)::float` on Snowflake
- [ ] Verify `measure='median'` and `measure='percentile'` likewise cast to float
- [ ] Confirm existing integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)