### PR TITLE
Add missing_encode macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Note: All methods in this package are meant to be used inline within a select st
 | [one_hot_encode](#one_hot_encode)         | ✅           | ✅             | ✅          |
 | [rare_category_encode](#rare_category_encode) | ✅      | ✅             | ✅          |
 | [frequency_encode](#frequency_encode)         | ✅           | ✅             | ✅          |
+| [missing_encode](#missing_encode)             | ✅           | ✅             | ✅          |
 | [cyclic_encode](#cyclic_encode)           | ✅           | ✅             | ✅          |
 | [exponentiate](#exponentiate)             | ✅           | ✅             | ✅          |
 | [interact](#interact)                     | ✅           | ✅             | ✅          |
@@ -73,6 +74,7 @@ Currently this package supports:
     * [one_hot_encode](#one_hot_encode)
     * [rare_category_encode](#rare_category_encode)
     * [frequency_encode](#frequency_encode)
+    * [missing_encode](#missing_encode)
     * [cyclic_encode](#cyclic_encode)
 * [Numerical Transformation](#numerical-transformation)
     * [exponentiate](#exponentiate)
@@ -284,6 +286,24 @@ This macro replaces each categorical value with its relative frequency (proporti
 ```sql
 {{ dbt_ml_inline_preprocessing.frequency_encode(
     column='country_code',
+   )
+}}
+```
+
+### missing_encode
+([source](macros/missing_encode.sql))
+
+This macro returns `1` if the column value is null and `0` otherwise. Useful for preserving missingness as a signal alongside any imputation macro.
+
+**Args:**
+
+- `column` (required): Name of the field to flag for missingness
+
+**Usage:**
+
+```sql
+{{ dbt_ml_inline_preprocessing.missing_encode(
+    column='user_age',
    )
 }}
 ```

--- a/integration_tests/data/data_missing_encode.csv
+++ b/integration_tests/data/data_missing_encode.csv
@@ -1,0 +1,8 @@
+input,expected
+hello,0
+world,0
+,1
+foo,0
+,1
+,1
+bar,0

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -200,3 +200,10 @@ models:
           arguments:
             actual: actual
             expected: expected
+
+  - name: test_missing_encode
+    data_tests:
+      - assert_equal:
+          arguments:
+            actual: actual
+            expected: expected

--- a/integration_tests/models/test_missing_encode.sql
+++ b/integration_tests/models/test_missing_encode.sql
@@ -1,0 +1,8 @@
+with data_missing_encode as (
+    select * from {{ ref('data_missing_encode') }}
+)
+
+select
+    {{ dbt_ml_inline_preprocessing.missing_encode('input') }} as actual,
+    expected
+from data_missing_encode

--- a/macros/missing_encode.sql
+++ b/macros/missing_encode.sql
@@ -1,0 +1,17 @@
+{% macro missing_encode(column) %}
+    {# Validate inputs #}
+    {% if column is none or column == '' %}
+        {{ exceptions.raise_compiler_error("missing_encode: 'column' parameter is required and cannot be empty.") }}
+    {% endif %}
+
+    {{ return(adapter.dispatch('missing_encode', 'dbt_ml_inline_preprocessing')(column)) }}
+{% endmacro %}
+
+{% macro default__missing_encode(column) %}
+
+    case
+        when {{ column }} is null then 1
+        else 0
+    end
+
+{% endmacro %}


### PR DESCRIPTION
## Summary

- Adds `missing_encode` macro that returns `1` if the column value is null and `0` otherwise
- Intended to be used alongside imputation macros to preserve missingness as a signal in ML pipelines
- No adapter-specific dispatch needed — `CASE WHEN col IS NULL` is standard SQL across all targets
- Adds integration test seed data, test model, and schema.yml entry; test passes cleanly with 0 warnings

## Test plan

- [ ] `dbt seed --select data_missing_encode && dbt run --select test_missing_encode && dbt test --select test_missing_encode` passes
- [ ] Null inputs produce `1`, non-null inputs produce `0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)